### PR TITLE
Ignore RUSTSEC-2024-0436

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,9 +13,15 @@ allow = [
 
 [advisories]
 version = 2
-# No fix for RSA, and this is a dependency from ssh_key crate to handle rsa ssh key.
-# https://rustsec.org/advisories/RUSTSEC-2023-0071
-ignore = ["RUSTSEC-2023-0071"]
+ignore = [
+    # No fix for RSA, and this is a dependency from ssh_key crate to handle rsa ssh key.
+    # https://rustsec.org/advisories/RUSTSEC-2023-0071
+    "RUSTSEC-2023-0071",
+    # Crate paste is unmaintained. The dependency is already removed in
+    # ratatui:master. Until a new release is available, ignore this in
+    # order to pass CI. (https://github.com/gitui-org/gitui/issues/2554)
+    { id = "RUSTSEC-2024-0436", reason = "The paste dependency is already removed from ratatui." }
+]
 
 [bans]
 multiple-versions = "deny"


### PR DESCRIPTION
cargo deny reports:

```
ID: RUSTSEC-2024-0436
Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md)
that this project is not longer maintained as well as archived the repository
Announcement: https://github.com/dtolnay/paste
Solution: No safe upgrade is available!
paste v1.0.15
└── ratatui v0.29.0
    ├── gitui v0.27.0
    └── tui-textarea v0.7.0
        └── gitui v0.27.0 (*)
```

In https://github.com/gitui-org/gitui/issues/2554 the decision was made to ignore this advisory, as ratatui already has removed paste in https://github.com/ratatui/ratatui/pull/1713 and we are just waiting for an upstream release.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:
-
-

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog